### PR TITLE
Sync Log in Daemons

### DIFF
--- a/lib/daemons/amqp_daemon.rb
+++ b/lib/daemons/amqp_daemon.rb
@@ -5,6 +5,7 @@ require File.join(ENV.fetch('RAILS_ROOT'), 'config', 'environment')
 
 raise "bindings must be provided." if ARGV.size == 0
 
+STDOUT.sync = true
 logger = Rails.logger
 
 conn = Bunny.new AMQPConfig.connect


### PR DESCRIPTION
`docker logs` doesn't show logging, force sync in STDOUT